### PR TITLE
Updated README usage code

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ const gen = immutagen(function*() {
   yield 1
   yield 2
   return 3
-})
-gen.next()                // { value: 1, next: [function] }
+})()                      // { value: 1, next: [function] }
 gen.next()                // { value: 1, next: [function] }
 gen.next().next()         // { value: 2, next: [function] }
 gen.next().next().next()  // { value: 3, next: undefined }

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ const gen = immutagen(function*() {
   yield 2
   return 3
 })()                      // { value: 1, next: [function] }
-gen.next()                // { value: 1, next: [function] }
-gen.next().next()         // { value: 2, next: [function] }
-gen.next().next().next()  // { value: 3, next: undefined }
+
+gen.next()                // { value: 2, next: [function] }
+gen.next()                // { value: 2, next: [function] }
+
+gen.next().next()         // { value: 3, next: undefined }
 ```
 
 `immutagen` takes a generator function and returns an immutable generator object. Instead of mutating itself upon each call to `next()`, it returns a new generation method `next` alongside the value it produces. When `next` is undefined, the generator is exhausted.


### PR DESCRIPTION
I'm pretty sure you need to call the `gen` function the first time before getting access to the `next` function...

Atleast the spec seems to imply that you need to start off the generator by calling the return value of `immutagen`:

```js
const next = immutagen(function*() {
  yield 3
  yield 4
})

assert.typeOf(next, 'function')

const { value, next: next2 } = next()  // <-- this call here
assert.equal(3, value)
assert.typeOf(next2, 'function')
```

Maybe I'm reading it wrong 😕

Also not sure if the rest of the example is correct (I think maybe the commented return values need to be moved up one line...)