### PR TITLE
Only use transform-runtime for tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,13 +3,18 @@
     "es2015",
     "stage-0"
   ],
-  "plugins": [
-    [
-      "transform-runtime",
-      {
-        "polyfill": false,
-        "regenerator": true
-      }
-    ]
-  ]
+  "env": {
+    "test": {
+      "plugins": [
+        [
+          "transform-runtime",
+          {
+            "polyfill": false,
+            "regenerator": true
+          }
+        ]
+      ]
+    }
+  }
+  
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A library for emulating immutable generators in JavaScript",
   "main": "immutagen.js",
   "scripts": {
-    "test": "mocha \"src/**/*.spec.js\" --compilers js:babel-register --reporter min",
-    "test:watch": "npm run test -- --watch",
+    "test": "BABEL_ENV=test mocha \"src/**/*.spec.js\" --compilers js:babel-register --reporter min",
+    "test:watch": "BABEL_ENV=test npm run test -- --watch",
     "build": "browserify -s immutagen src/immutagen.js -o immutagen.js -t [ babelify ]",
     "release": "xyz",
     "release:patch": "xyz --increment patch",


### PR DESCRIPTION
Using immutagen in my project I was getting an error that babel-plugin-transform-runtime is not available, which is true because it is only in devDependencies. It's only used in the tests so I put it in a test env